### PR TITLE
Update frontendlib and increment version number

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "deck-roulette",
-	"version": "1.1.2",
+	"version": "1.1.3",
 	"description": "A plugin that allows you to navigate to a random game in your library or a Steam Collection.",
 	"scripts": {
 		"build": "shx rm -rf dist && rollup -c",
@@ -41,7 +41,7 @@
 		"typescript": "^4.9.5"
 	},
 	"dependencies": {
-		"decky-frontend-lib": "^3.21.0",
+		"decky-frontend-lib": "^3.25.0",
 		"react-icons": "^4.8.0"
 	},
 	"pnpm": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2,8 +2,8 @@ lockfileVersion: '6.0'
 
 dependencies:
   decky-frontend-lib:
-    specifier: ^3.21.0
-    version: 3.21.0
+    specifier: ^3.25.0
+    version: 3.25.0
   react-icons:
     specifier: ^4.8.0
     version: 4.8.0
@@ -430,8 +430,8 @@ packages:
     resolution: {integrity: sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ==}
     dev: true
 
-  /decky-frontend-lib@3.21.0:
-    resolution: {integrity: sha512-BZY+F9HKhjF0zthoBdQxbluZ/37UyjlzCCpcC6dQfOeAAPmjFDATs/FF/n9qo9B+NMepgWUXpStZR0becE9EOw==}
+  /decky-frontend-lib@3.25.0:
+    resolution: {integrity: sha512-2lBoHS2AIRmuluq/bGdHBz+uyToQE7k3K/vDq1MQbDZ4eC+8CGDuh2T8yZOj3D0yjGP2MdikNNAWPA9Z5l2qDg==}
     dev: false
 
   /deepmerge@4.3.1:
@@ -514,8 +514,8 @@ packages:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
     dev: true
 
-  /fsevents@2.3.2:
-    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+  /fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
     requiresBuild: true
@@ -739,7 +739,7 @@ packages:
     engines: {node: '>=10.0.0'}
     hasBin: true
     optionalDependencies:
-      fsevents: 2.3.2
+      fsevents: 2.3.3
     dev: true
 
   /safe-buffer@5.2.1:


### PR DESCRIPTION
This PR updates the decky-frontend-lib dependency and increments the version number in the `package.json` file. The changes were made by running the VS code task `updatefrontendlib`.

- Updated decky-frontend-lib from 3.21.0 to 3.25.0.
- Incremented version from 1.1.2 to 1.1.3.

Tested on:

- Steam OS 3.5.19
- Steam Client 1715635533
- Decky v2.12.0
